### PR TITLE
added conditional string compilation to module_eval and class_eval

### DIFF
--- a/opal/corelib/basic_object.rb
+++ b/opal/corelib/basic_object.rb
@@ -37,8 +37,13 @@ class BasicObject
   alias eql? ==
   alias equal? ==
 
-  def instance_eval(&block)
-    Kernel.raise ArgumentError, "no block given" unless block
+  def instance_eval(*args, &block)
+    
+    if !block
+      compiled = Opal.compile("lambda {\n#{args[0]}\n}")
+      raise ArgumentError, 'you must require "opal-parser" to eval strings' unless compiled
+      block = `eval(#{compiled})`
+    end
 
     %x{
       var old = block.$$s,

--- a/opal/corelib/module.rb
+++ b/opal/corelib/module.rb
@@ -373,8 +373,13 @@ class Module
   def extended(mod)
   end
 
-  def module_eval(&block)
-    raise ArgumentError, 'no block given' unless block
+  def module_eval(*args, &block)
+    
+    if !block
+      compiled = Opal.compile("lambda {\n#{args[0]}\n}")
+      raise ArgumentError, 'you must require "opal-parser" to eval strings' unless compiled
+      block = `eval(#{compiled})`
+    end
 
     %x{
       var old = block.$$s,
@@ -388,7 +393,7 @@ class Module
     }
   end
 
-  alias class_eval module_eval
+  alias_method :class_eval, :module_eval
 
   def module_exec(&block)
     %x{


### PR DESCRIPTION
gracefully fails if opal-parser has not been required

This should close #480
